### PR TITLE
Charcoal: Dont try to search if user hasn't entered a search term

### DIFF
--- a/themes/charcoal/searchform.php
+++ b/themes/charcoal/searchform.php
@@ -1,5 +1,5 @@
 <?php if ( !defined( 'HABARI_PATH' ) ) { die('No direct access'); } ?>
-<form method="get" id="search-form" action="<?php URL::out('display_search'); ?>">
+<form method="get" id="search-form" action="<?php URL::out('display_search'); ?>" onsubmit="if ( document.getElementById('search-box').value == '<?php printf( _t("Search %s"), str_replace("'", "\'", Options::get("title")) ); ?>' ) { return false; }">
 	<input type="text" name="criteria" id="search-box" value="<?php if ( isset( $criteria ) ) { echo htmlentities($criteria, ENT_COMPAT, 'UTF-8');} else { printf( _t("Search %s"), Options::get("title")) ;}  ?>" onfocus="if (this.value == '<?php printf( _t("Search %s"), str_replace("'", "\'", Options::get("title")) ); ?>') {this.value = '';}" onblur="if (this.value == '') {this.value = '<?php printf( _t("Search %s"), str_replace("'", "\'", Options::get("title")) ); ?>';}" >
 	<input type="submit" id="search-btn" value="" title="<?php _e( "Go" ); ?>">
 </form>


### PR DESCRIPTION
On Charcoal, if you submit the search form without entering any text, it will try to search the "Search <site name>". This commit should fix it.
