### PR TITLE
add a help toggler to the theme page

### DIFF
--- a/admin/css/admin.css
+++ b/admin/css/admin.css
@@ -1575,7 +1575,7 @@ body.page-options .item {
 	font-weight: bold;
 }
 
-.plugins .item a.help, .plugins .item a.help.active:hover {
+.plugins .item a.help, .plugins .item a.help.active:hover, .currenttheme a.help, .currenttheme a.help.active:hover {
 	text-indent: -10000px;
 	background: transparent url('../images/help_icon.png') scroll no-repeat;
 	width: 15px;
@@ -1584,7 +1584,7 @@ body.page-options .item {
 	outline: none;
 }
 
-.plugins .item a.help:hover, .plugins .item a.help.active {
+.plugins .item a.help:hover, .plugins .item a.help.active, .currenttheme a.help:hover, .currenttheme a.help.active {
 	background-image: url('../images/help_icon_over.png');
 }
 
@@ -1605,11 +1605,11 @@ body.page-options .item {
 	-webkit-border-radius: 5px;
 }
 
-.plugins .pluginhelp {
+.plugins .pluginhelp, .currenttheme #themehelp {
 	display: none;
 }
 
-.plugins .pluginhelp.active {
+.plugins .pluginhelp.active, .currenttheme #themehelp.active {
 	display: block;
 }
 
@@ -1638,91 +1638,90 @@ body.page-options .item {
 	text-indent: -2px;
 }
 
-/*-- PLUGINS HELP */
-.pluginhelp .help {
+/*-- PLUGIN AND THEME HELP */
+.pluginhelp .help, .currenttheme #themehelp .help {
 	line-height: 1.5em;
 }
 
-.pluginhelp .help p {
+.pluginhelp .help p, .currenttheme #themehelp .help p {
 	margin-bottom: 5px;
 }
 
-.pluginhelp .help h3 {
+.pluginhelp .help h3, .currenttheme #themehelp .help h3 {
 	margin-top: 10px;
 	margin-bottom: 5px;
 	font-size: 160%;
 	font-weight: bold;
 }
 
-.pluginhelp .help h4 {
+.pluginhelp .help h4, .currenttheme #themehelp .help h4 {
 	margin-top: 7px;
 	margin-bottom: 3px;
 	font-size: 110%;
 	font-style: italic;
 }
 
-.pluginhelp .help code {
+.pluginhelp .help code, .currenttheme #themehelp .help code {
 	font-family: Monaco, "Bitstream Vera Sans Mono", "Lucida Console", Terminal, monospace;
 	white-space: pre;
 	padding: 0.25em 0.5em 0;
 	background-color: #e3e3e3;
 }
 
-.pluginhelp .help code.block {
+.pluginhelp .help code.block, .currenttheme #themehelp .help code.block {
 	display: block;
 }
 
-.pluginhelp p.warning {
+.pluginhelp p.warning, .currenttheme #themehelp .help p.warning {
 	padding-left: 20px;
 	background: url('../images/warning.png') no-repeat left center;
 	color: #FF4500;
 }
 
-.pluginhelp .help em {
+.pluginhelp .help em, .currenttheme #themehelp .help em {
 	font-style: italic;
 }
 
-.pluginhelp .help strong {
+.pluginhelp .help strong, .currenttheme #themehelp .help em {
 	font-weight: bold;
 }
 
 
-.pluginhelp .help a, .pluginhelp .help a:visited {
+.pluginhelp .help a, .pluginhelp .help a:visited, .currenttheme #themehelp .help a, .currenttheme #themehelp .help a:visited {
 	color: #555;
 	text-decoration: underline;
 }
 
-.pluginhelp .help a:hover, .pluginhelp .help a:focus {
+.pluginhelp .help a:hover, .pluginhelp .help a:focus, .currenttheme #themehelp .help a:hover, .currenttheme #themehelp .help a:focus {
 	color: #000;
 }
 
-.pluginhelp .help ol, .pluginhelp .help ul {
+.pluginhelp .help ol, .pluginhelp .help ul, .currenttheme #themehelp .help ol, .currenttheme #themehelp .help ul {
 	margin: 5px 20px;
 }
 
-.pluginhelp .help ol, .pluginhelp .help ul ol {
+.pluginhelp .help ol, .pluginhelp .help ul ol, .currenttheme #themehelp .help ol, .currenttheme #themehelp .help ul ol {
 	list-style: decimal;
 }
 
-.pluginhelp .help ol ol {
+.pluginhelp .help ol ol, .currenttheme #themehelp .help ol ol {
 	list-style: lower-latin;
 }
 
-.pluginhelp .help ul, .pluginhelp .help ol ul {
+.pluginhelp .help ul, .pluginhelp .help ol ul, .currenttheme #themehelp .help ul, .currenttheme #themehelp .help ol ul {
 	list-style: disc;
 }
 
-.pluginhelp .help ul ul {
+.pluginhelp .help ul ul, .currenttheme #themehelp .help ul ul {
 	list-style: circle;
 }
 
-.pluginhelp .help ol ol, .pluginhelp .help ul ul, .pluginhelp .help ul ol, .pluginhelp .help ol ul {
+.pluginhelp .help ol ol, .pluginhelp .help ul ul, .pluginhelp .help ul ol, .pluginhelp .help ol ul, .currenttheme #themehelp .help ol ol, .currenttheme #themehelp .help ul ul, .currenttheme #themehelp .help ul ol, .currenttheme #themehelp .help ol ul {
 	margin-top: 0;
 	margin-bottom: 0;
 }
 
 /*- THEMES PAGE */
-
 body.page-themes .availablethemes .item {
     border: 1px dotted #efefef;
     text-align: center;
@@ -1756,6 +1755,10 @@ body.page-themes .head {
     height: 3em;
     white-space: nowrap;
     margin: 10px 0 0 0 ;
+}
+
+body.page-themes .head a.help {
+	float: right;
 }
 
 body.page-themes .availablethemes .themeinfo {

--- a/admin/js/admin.js
+++ b/admin/js/admin.js
@@ -422,21 +422,12 @@ var itemManage = {
 	}
 };
 
-// Plugin Management
-var pluginManage = {
+// Help Toggler
+var helpToggler = {
 	init: function() {
-		// Return if we're not on the plugins page
-		if (!$('.page-plugins').length) {return;}
-
-		$('.plugins .item').hover( function() {
-			$(this).find('#pluginconfigure:visible').parent().css('background', '#FAFAFA');
-		}, function() {
-			$(this).find('#pluginconfigure:visible').parent().css('background', '');
-	  	});
-		
-		$('.plugins .item a.help').click(function() {
-			var help = $('.pluginhelp', $(this).parents('.item'));
-						
+		$('.plugins .item a.help, .currenttheme a.help').click(function() {
+			var help = $('.pluginhelp', $(this).parents('.item')).add( $('.currenttheme #themehelp') );
+									
 			if( help.hasClass('active') ) {
 				help.slideUp();
 				help.add(this).removeClass('active');
@@ -450,6 +441,22 @@ var pluginManage = {
 			
 		});
 	}
+}
+
+// Plugin Management
+var pluginManage = {
+	init: function() {
+		// Return if we're not on the plugins page
+		if (!$('.page-plugins').length) {return;}
+
+		$('.plugins .item').hover( function() {
+			$(this).find('#pluginconfigure:visible').parent().css('background', '#FAFAFA');
+		}, function() {
+			$(this).find('#pluginconfigure:visible').parent().css('background', '');
+	  	});
+	
+		helpToggler.init();
+	}
 };
 
 // Theme Management
@@ -462,8 +469,10 @@ var themeManage = {
 		axis: 'y'
 	},
 	init: function() {
-		// Return if we're not on the plugins page
+		// Return if we're not on the themes page
 		if (!$('.page-themes').length) {return;}
+		
+		helpToggler.init();
 
 		// Adding available blocks
 		$('#block_instance_add').live('click', function() {

--- a/admin/themes.php
+++ b/admin/themes.php
@@ -6,6 +6,14 @@
 	<div class="item clear">
 		<div class="head">
 
+			<?php if ( isset( $active_theme['info']->help ) ):
+				if( Controller::get_var('help') == $active_theme['dir'] ): ?>
+				<a class="help active" href="<?php URL::out( 'admin', 'page=themes' ); ?>"><?php _e('Help'); ?></a>
+				<?php else: ?>
+				<a class="help" href="<?php URL::out( 'admin', 'page=themes&help=' . $active_theme['dir'] ); ?>"><?php _e('Help'); ?></a>
+			<?php endif;
+			endif; ?>
+
 			<a href="<?php echo $active_theme['info']->url; ?>" class="plugin"><?php echo $active_theme['info']->name; ?></a> <span class="version dim"><?php echo $active_theme['info']->version; ?></span> <span class="dim"><?php _e('by'); ?></span> 
 			<?php
 			$authors = array();
@@ -26,6 +34,7 @@
 				<li><a href="#"><?php _e('v'); ?><?php echo $active_theme['info']->update; ?> <?php _e('Update Available'); ?></a></li>
 			</ul>
 			<?php endif; ?>
+
 		</div>
 
 		<div>
@@ -37,6 +46,13 @@
 			<?php endif; ?>
 		</div>
 	</div>
+
+	<?php if ( isset( $active_theme['info']->help ) ): ?>
+	<div id="themehelp" class="item clear<?php if( Controller::get_var('help') == $active_theme['dir'] ): ?> active<?php endif; ?>">
+		<h3><?php _e( "Help" ); ?></h3>
+		<div class="help"><?php echo (string) $active_theme['info']->help->value; ?></div>
+	</div>
+	<?php endif; ?>
 
 	<?php
 	// Capture the admin config output.  If nothing is there, don't output the section


### PR DESCRIPTION
This pull request fixes habari/habari#334 by creating a toggler on the theme page to enable the display of help information for the active theme. The help information is pulled from theme.xml and the entire process is reminiscent of the plugin help information system. Indeed, most of the CSS and Javascript is shared between the two.
