### PR TITLE
allow the forcing of a scope when calling ->area()

### DIFF
--- a/classes/theme.php
+++ b/classes/theme.php
@@ -1198,7 +1198,7 @@ class Theme extends Pluggable
 
 		$active_scope = 0;
 		foreach ( $scopes as $scope_id => $scope_object ) {
-			if ( $this->check_scope_criteria( $scope_object->criteria ) ) {
+			if ( $this->check_scope_criteria( $scope_object->criteria ) || $scope == $scope_object->name ) {
 				$scope_block_count = DB::get_value( 'SELECT count( *) FROM {blocks_areas} ba WHERE ba.scope_id = ?', array( $scope_object->id ) );
 				if ( $scope_block_count > 0 ) {
 					$active_scope = $scope_object->id;
@@ -1206,7 +1206,7 @@ class Theme extends Pluggable
 				break;
 			}
 		}
-
+		
 		$area_blocks = $this->get_blocks( $area, $active_scope, $theme );
 
 		$this->area = $area;


### PR DESCRIPTION
This properly implements the $theme->area() class by actually respecting a passed scope.
