### PR TITLE
fixes #357

### DIFF
--- a/classes/rawphpengine.php
+++ b/classes/rawphpengine.php
@@ -196,7 +196,7 @@ class RawPHPEngine extends TemplateEngine
 
 	public function add_template($name, $file, $replace = false)
 	{
-		if($replace || empty($this->available_templates[$name])) {
+		if($replace || !in_array($name, $this->available_templates)) {
 			$this->available_templates[] = $name;
 			$this->template_map[$name] = $file;
 		}


### PR DESCRIPTION
$theme_engine->available_templates stores templates as values, not keys.
