### PR TITLE
fixes missing is_object check in mzingi theme.php

### DIFF
--- a/themes/mzingi/theme.php
+++ b/themes/mzingi/theme.php
@@ -58,7 +58,7 @@ class Mzingi extends Theme
 		//For Asides loop in sidebar.php
 		$this->assign( 'asides', Posts::get( 'asides' ) );
 
-		if ( $this->request->display_entries_by_tag ) {
+		if ( is_object($this->request) && $this->request->display_entries_by_tag ) {
 			if ( count( $this->include_tag ) && count( $this->exclude_tag ) == 0 ) {
 				$this->tags_msg = _t( 'Posts tagged with %s', array( Format::tag_and_list( $this->include_tag ) ) );
 			}


### PR DESCRIPTION
Installed the current head checkout today to develop a new site for http://blackndeather.org and noticed - by the pestering "Notice:" error message - that there was something amiss with the Mzingi theme. Compared it with the current Charcoal, and fixed it.
