### PR TITLE
Avoid warning message from array_merge in autoload for sites without classes/ or handlers/

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -49,8 +49,8 @@ function habari_autoload( $class_name )
 		if ( ( $site_user_dir = Site::get_dir( 'user' ) ) != HABARI_PATH . '/user' ) {
 			// We are dealing with a site defined in /user/sites/x.y.z
 			// Add the available files in that directory in the $files array.
-			$glob_classes = glob( $site_user_dir . '/classes/*.php' );
-			$glob_handlers = glob( $site_user_dir . '/handlers/*.php' );
+			$glob_classes = Utils::glob( $site_user_dir . '/classes/*.php' );
+			$glob_handlers = Utils::glob( $site_user_dir . '/handlers/*.php' );
 			$glob = array_merge( $glob_classes, $glob_handlers );
 			if ( $glob !== false && !empty( $glob ) ) {
 				$fnames = array_map( $lower_basename, $glob );


### PR DESCRIPTION
Make calls to glob() use Utils::glob both for consistency and to prevent PHP warning if site has empty /classes/ or /handlers/ folders.
Utils::glob always returns an array, and so array_merge won't yield a warning, whereas plain glob() will.
