### PR TITLE
Add namespaces to method_exists calls when the class name is passed as s...

### DIFF
--- a/classes/formui.php
+++ b/classes/formui.php
@@ -1317,8 +1317,8 @@ class FormControl extends FormComponents
 				$params = array_merge( array( $this->value, $this, $this->container ), $validator );
 				$valid = array_merge( $valid, call_user_func_array( $validator_fn, $params ) );
 			}
-			elseif ( method_exists( 'FormValidators', $validator_fn ) ) {
-				$validator_fn = array( 'FormValidators', $validator_fn );
+			elseif ( method_exists( 'Habari\FormValidators', $validator_fn ) ) {
+				$validator_fn = array( 'Habari\FormValidators', $validator_fn );
 				$params = array_merge( array( $this->value, $this, $this->container ), $validator );
 				$valid = array_merge( $valid, call_user_func_array( $validator_fn, $params ) );
 			}


### PR DESCRIPTION
...tring. There might be more. Do not merge before we had some thoughts if there might be more method_exist() calls that don't work. At least in FormUI, there seem to be none.

Eventually fixes #471 and is relevant to #400.
