### PR TITLE
Allow whitespace character containing directories in RewriteBase

### DIFF
--- a/handlers/installhandler.php
+++ b/handlers/installhandler.php
@@ -1076,7 +1076,7 @@ class InstallHandler extends ActionHandler
 		);
 		$rewrite_base = trim( dirname( $_SERVER['SCRIPT_NAME'] ), '/\\' );
 		if ( $rewrite_base != '' ) {
-			$htaccess['rewrite_base'] = 'RewriteBase /' . $rewrite_base;
+			$htaccess['rewrite_base'] = 'RewriteBase "/' . $rewrite_base . '"';
 		}
 
 		return $htaccess;
@@ -1148,7 +1148,7 @@ class InstallHandler extends ActionHandler
 		$htaccess = $this->htaccess();
 		if ( $rewritebase ) {
 			$rewrite_base = trim( dirname( $_SERVER['SCRIPT_NAME'] ), '/\\' );
-			$htaccess['rewrite_base'] = 'RewriteBase /' . $rewrite_base;
+			$htaccess['rewrite_base'] = 'RewriteBase "/' . $rewrite_base . '"';
 		}
 		$file_contents = "\n" . implode( "\n", $htaccess ) . "\n";
 


### PR DESCRIPTION
Adding quotes around RewriteBase address to allow for directory names containing spaces
