### PR TITLE
Prevent backslash from tripping logging with PostgreSQL

### DIFF
--- a/classes/logentry.php
+++ b/classes/logentry.php
@@ -223,6 +223,12 @@ class LogEntry extends QueryRecord
 			$this->fields['data'] = serialize( $this->fields['data'] );
 		}
 
+		// data is BLOB/BYTEA, PostgreSQL treats \ specially for BYTEA, escape it to \\ to
+		// avoid processing (invalid) escapes sequences.
+		if ( DB::get_driver_name() == 'pgsql' && is_string($this->fields['data']) ) {
+			$this->fields['data'] = str_replace('\\', '\\\\', $this->fields['data'] );
+		}
+
 		Plugins::filter( 'insert_logentry', $this );
 		parent::insertRecord( DB::table( 'log' ) );
 


### PR DESCRIPTION
The "data" field is of type BYTEA (BLOB in other databases). It is observed
that PHP is flawed with interpreting PARAM_LOB, it accepts/returns a file stream
for one database connector (pgsql) and a string for others (sqlite, mysql?).

Since modifying the whole API just to satisfy a single data type addition is
a bit overkill, drop that idea and patch the string for postgresql such that it
is not possible to die on data like `Habari\Method`. (escape sequences for
[PostgreSQL are documented for bytea](http://www.postgresql.org/docs/devel/static/datatype-binary.html)).
