### PR TITLE
Fix postgresql upgrade script wrt sequences

### DIFF
--- a/schema/pgsql/connection.php
+++ b/schema/pgsql/connection.php
@@ -104,7 +104,7 @@ class PGSQLConnection extends DatabaseConnection
 			else if ( preg_match( "|CREATE DATABASE ([^ ]*)|", $qry, $matches ) ) {
 				array_unshift( $cqueries, $qry );
 			}
-			else if ( preg_match( "|CREATE SEQUENCE ([^ ]*)|", $qry, $matches ) ) {
+			else if ( preg_match( "|CREATE SEQUENCE ([^ ;]*)|", $qry, $matches ) ) {
 				$cseqqueries[strtolower( $matches[1] )] = $qry;
 			}
 			else if ( preg_match( "|ALTER SEQUENCE ([^ ]*)|", $qry, $matches ) ) {


### PR DESCRIPTION
The upgrade script tried to re-create the sequences even if it was already
existing. It turns out that the name `foo;` was compared to `foo` because the
query is actually `CREATE SEQUENCE foo;`. Adjust the regex to ignore the `;`.
