### PR TITLE
Do not create link when website is empty for recent comments box

### DIFF
--- a/plugins/coreblocks/block.recent_comments.php
+++ b/plugins/coreblocks/block.recent_comments.php
@@ -2,12 +2,20 @@
 <ul id="recent_comments">
 	<?php $comments = $content->recent_comments; foreach( $comments as $comment): ?>
 		<li>
-			<a href="<?php echo $comment->url ?>">
-				<?php echo $comment->name; ?>
-			</a> on
-			<a href="<?php echo $comment->post->permalink; ?>">
-				<?php echo $comment->post->title; ?>
-			</a>
+<?php
+		if ( $comment->url ) {
+			$name_html = sprintf('<a class="username" href="%s">%s</a>',
+				$comment->url, $comment->name);
+		}
+		else {
+			$name_html = sprintf('<span class="username">%s</span>',
+				$comment->name);
+		}
+		$post_html = sprintf('<a href="%s">%s</a>',
+			$comment->post->permalink, $comment->post->title);
+		// @locale An item in the "Comments" menu list showing that a user commented on a post ("user on post")
+		_e('%1$s on %2$s', array( $name_html, $post_html ));
+?>
 		</li>
 	<?php endforeach; ?>
 </ul>


### PR DESCRIPTION
Add class such that themes can use `#recent_comments .username` for styling
names and make the "user [commented] on post" string translatable.
