### PR TITLE
Use native placeholder on modern browsers

### DIFF
--- a/admin/js/admin.js
+++ b/admin/js/admin.js
@@ -1360,17 +1360,21 @@ var liveSearch = {
 		liveSearch.searchPrompt = liveSearch.input.attr('placeholder');
 		liveSearch.prevSearch = liveSearch.getSearchText();
 
+		if (document.createElement('input').placeholder === undefined) {
+			liveSearch.input
+				.focus( function() {
+					if ( $.trim( liveSearch.input.val() ) == liveSearch.searchPrompt ) {
+						liveSearch.input.val('');
+					}
+				})
+				.blur( function () {
+					if ( $.trim( liveSearch.input.val() ) === '' ) {
+						liveSearch.input.val( liveSearch.searchPrompt );
+					}
+			});
+		}
+
 		liveSearch.input
-			.focus( function() {
-				if ( $.trim( liveSearch.input.val() ) == liveSearch.searchPrompt ) {
-					liveSearch.input.val('');
-				}
-			})
-			.blur( function () {
-				if ( $.trim( liveSearch.input.val() ) === '' ) {
-					liveSearch.input.val( liveSearch.searchPrompt );
-				}
-			})
 			.keyup( function( event ) {
 				var code = event.keyCode;
 


### PR DESCRIPTION
On admin area, avoid using focus and blur events on form input if browser has native support for `placeholder`.
