### PR TITLE
Enhancements to CoreBlock Monthly Archives and Tag Archives

### DIFF
--- a/plugins/coreblocks/block.cloud.tag_archives.php
+++ b/plugins/coreblocks/block.cloud.tag_archives.php
@@ -1,23 +1,8 @@
 <?php if ( !defined( 'HABARI_PATH' ) ) { die( 'No direct access' ); } ?>
-<?php
-/*  before outputting the tags we must run through them once to find the min and max
-    post counts, these are needed to calculate the proper per-post size increment between
-    the user's defined min/max font sizes
- */
-$tags = $content->tags;
-if ($content->cloud_max != '') { $maxSize = $content->cloud_max; } else { $maxSize = 4; }
-if ($content->cloud_min != '') { $minSize = $content->cloud_min; } else { $minSize = 0.6; }
-$minPosts = 1000;
-$maxPosts = 1;
-foreach ($tags as $tag) {
-    if ($tag['count'] > $maxPosts) { $maxPosts = $tag['count']; }
-    if ($tag['count'] < $minPosts) { $minPosts = $tag['count']; }
-}
-$sizeIncrement = round(($maxSize - $minSize) / ($maxPosts - $minPosts),1);
-?>
+<?php $tags = $content->tags; ?>
 <div id="tag_archives">
     <?php $tags = $content->tags; foreach( $tags as $tag ): ?>
-        <span style="font-size: <?php echo ($minSize + round((($tag['count'] - $minPosts) * $sizeIncrement),1)); ?>em;" class="cloud-tag">
+        <span style="font-size: <?php echo ($content->cloud_min + round((($tag['count'] - $content->min_post_count) * $content->size_increment),1)); ?>em;" class="cloud-tag">
             <a  href="<?php echo $tag[ 'url' ]; ?>"
                 title="View entries tagged '<?php echo $tag[ 'tag' ]; ?>'">
                 <?php echo $tag[ 'tag' ]; ?>

--- a/plugins/coreblocks/block.dropdown.tag_archives.php
+++ b/plugins/coreblocks/block.dropdown.tag_archives.php
@@ -7,7 +7,7 @@
 
 		<option value=''>by tag</option>
 		<?php $tags = $content->tags; foreach( $tags as $tag ): ?>
-			<option value="<?php echo $tag[ 'url' ]; ?>"><?php echo $tag[ 'tag' ] . $tag[ 'count' ];
+			<option value="<?php echo $tag[ 'url' ]; ?>"><?php echo $tag[ 'tag' ] . ' ('. $tag[ 'count' ] . ')';
 	?></option>
 		<?php endforeach; ?>
 </select>

--- a/plugins/coreblocks/block.tag_archives.php
+++ b/plugins/coreblocks/block.tag_archives.php
@@ -5,7 +5,7 @@
 	<a href="<?php echo $tag[ 'url' ]; ?>" title="View entries tagged '<?php
 		echo $tag[ 'tag' ];
 	?>'"><?php
-		echo $tag[ 'tag' ] . $tag[ 'count' ];
+		echo $tag[ 'tag' ] . ' ('. $tag[ 'count' ] . ')';
 	?></a>
 		</li>
 	<?php endforeach; ?>

--- a/plugins/coreblocks/coreblocks.plugin.php
+++ b/plugins/coreblocks/coreblocks.plugin.php
@@ -300,15 +300,16 @@ class CoreBlocks extends Plugin
 	{
 		$tags = array();
 		$results = Tags::vocabulary()->get_tree();
+        $minCount = 1000000;
+        $maxCount = 1;
+        if ($block->cloud_max == '') { $block->cloud_max = 3; }
+        if ($block->cloud_min == '') { $block->cloud_min = 0.8; }
+        $sizeIncrement = 0;
 
 		foreach( $results as $result ) {
 
 			$count = '';
-			if ( $block->show_counts && $block->style != 'cloud') {
-				$count = " (" . Posts::count_by_tag( $result->term_display, "published") . ")";
-			} else if ($block->show_counts) {
-                /* we don't want text parens for the cloud because the post count is used
-                to derive the span em sizes */
+			if ( $block->show_counts) {
                 $count = Posts::count_by_tag( $result->term_display, "published");
             }
 
@@ -318,7 +319,14 @@ class CoreBlocks extends Plugin
 				'count' => $count,
 				'url' => $url,
 				);
+
+            if ($count > $maxCount) { $maxCount = $count; }
+            if ($count < $minCount) { $minCount = $count; }
 		}
+
+        $sizeIncrement = round(($block->cloud_max - $block->cloud_min) / ($maxCount - $minCount),1);
+        $block->size_increment = $sizeIncrement;
+        $block->min_post_count = $minCount;
 
 		$block->tags = $tags;
 	}


### PR DESCRIPTION
Changes to CoreBlocks are as follows:

1) Tag Archives insertion of post count parentheses moved out of plugin and into template. This is output styling and should be left to the theme author's discretion, not hardcoded inside the plugin.

2) New tag archive style: cloud. Individual tag font sizes are calculated based on relative post count within a range of (em) specified by the user.

3) Added ability to control monthly archive list order (newest to oldest or vice versa).

All changes tested and functioning on habari:master fork.
