### PR TITLE
Adjust selected splitter background so the button correctly shows the state

### DIFF
--- a/admin/css/admin.css
+++ b/admin/css/admin.css
@@ -2599,15 +2599,18 @@ ul.tabs li.last-child {
 	border: none;
 }
 
-ul.tabs li.ui-tabs-selected {
+ul.tabs li.ui-tabs-selected, 
+ul.tabs li.ui-tabs-active {
 	background-position: -10px bottom;
 }
 
-ul.tabs li.ui-tabs-selected.first-child {
+ul.tabs li.ui-tabs-selected.first-child,
+ul.tabs li.ui-tabs-active.first-child {
 	background-position: left bottom;
 }
 
-ul.tabs li.ui-tabs-selected.last-child {
+ul.tabs li.ui-tabs-selected.last-child,
+ul.tabs li.ui-tabs-active.last-child {
 	background-position: right bottom;
 }
 


### PR DESCRIPTION
Fixes habari/habari#483 for 0.9.2. This isn't really an issue on master/trunk as the admin interface is in limbo and it currently doesn't experience this issue.
