### PR TITLE
0.9.1: support arbitrary classes for images in the shortcode. the pbem_s...

### DIFF
--- a/plugins/flickrsilo/flickrsilo.plugin.php
+++ b/plugins/flickrsilo/flickrsilo.plugin.php
@@ -1092,8 +1092,8 @@ FLICKR;
 			$markup .= '<img src="';
 			$markup .= $f->getPhotoURL( $flickr, $size );
 			$markup .= '"';
-			if ( $post->author->info->pbem_class ) {
-				$markup .= ' class="' . $post->author->info->pbem_class . '"';
+			if ( isset( $attr_array['class'] ) ) {
+				$markup .= ' class="' . $attr_array['class'] . '"';
 			}
 			$markup .= '></a>';
 		} else {


### PR DESCRIPTION
...torage_flickr plugin has been updated to use this, so there is no reason for the silo to know anything specific about that plugin.

One commit made after 0.9.1 was tagged and released.
