### PR TITLE
Fix 0.9.2 installer

### DIFF
--- a/handlers/installhandler.php
+++ b/handlers/installhandler.php
@@ -995,7 +995,7 @@ class InstallHandler extends ActionHandler
 
 	public function activate_theme()
 	{
-		$theme_dir = $this->handler_vars['theme'];
+		$theme_dir = $this->handler_vars['theme_dir'];
 
 		// set the user_id in the session in case theme activation methods need it
 		if ( ! $u = User::get_by_name( $this->handler_vars['admin_username'] ) ) {

--- a/installer/db_setup.php
+++ b/installer/db_setup.php
@@ -223,7 +223,7 @@
 			<div class="item clear clearfix">
 				<div class="head">
 					<span class="checkbox">
-						<input type="radio" name="theme" value="<?php echo $key; ?>"
+						<input type="radio" name="theme_dir" value="<?php echo $theme['dir']; ?>"
 							id="theme_<?php echo $theme['dir']; ?>" tabindex="<?php echo $tab++ ?>"
 							class="theme_selection"
 							data-requires="<?php echo isset($theme['requires']) ? (string)InstallHandler::get_feature_list($theme['requires']) : ''; ?>"


### PR DESCRIPTION
Fix the issue where the installer encounters a problem when trying to set the theme after stopping at the config screen prompting the user to manually create the config.php file.

Backport to 0.9.2 too :smile:
